### PR TITLE
Update sox_play.js

### DIFF
--- a/sox_play.js
+++ b/sox_play.js
@@ -280,6 +280,10 @@ module.exports = function(RED) {
                             node.inputRate = msg.rate;
                         }
                         spawnPlayStream();
+                        // without the following line my NodeRed on RPI400 did not play streams (coming from pico2wave node)
+                        // sox always compained empty stream...
+                        writeStdin(msg.payload);
+                        // end of patch
                     } else {
                         writeStdin(msg.payload);
                     }


### PR DESCRIPTION
had issues playing streams. In my case stream is generated by pico2wave node and soxplay did not play any sound.
Sox always compained empty stream...

To be honest I don't understand the code and just had luck to fix it for me. It it probably not a real valid fix!